### PR TITLE
Add parameterized reports for workshop communication

### DIFF
--- a/workshop_communication/01_announcement.rmd
+++ b/workshop_communication/01_announcement.rmd
@@ -1,0 +1,59 @@
+---
+title: "Workshop Announcement"
+output: html_document
+params:
+  workshop_date: "2022-02-17 09:00"
+  contact_person: "Rose Hartman"
+  contact_email: "hartmanr1@chop.edu"
+  signup_link: "https://redcap.link/feb2022_r_for_clinical_data"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+library(lubridate)
+source("communication_functions.r")
+
+workshop_date <- ymd_hm(params$workshop_date, tz = "EST")
+```
+
+Hello all,
+ 
+Exciting news: It's time for another "**Intro to R for Clinical Data**" workshop!
+ 
+On `r format(workshop_date, '%A, %B %d')` from `r print_time(workshop_date)` - `r print_time(workshop_date + dhours(5))`, Arcus Education will be hosting our gentle introduction to data science for healthcare professionals (e.g. MDs, RNs, NPs, data managers, clinical researchers) and others who interact with clinical data. This course is geared towards beginners who are comfortable with Excel but have no programming background. 
+ 
+The workshop will cover why and how to get started using the R statistical programming language in your work. We'll talk about how to import data, transform data, and create lovely data visualizations in R, all while setting you up with best practices for creating reproducible reports. 
+ 
+To sign up for this exciting workshop, please visit `r params$signup_link`. This workshop is limited to 40 participants with a CHOP email address, so please be sure to sign up soon if you are interested in attending. If you sign up but find that you are no longer able to attend, please let us know so we can extend your spot to someone else. 
+
+Note that this will be a repeat of workshops we've offered previously. If you've already attended this workshop in the past and you're looking for ways to take the next steps in your R journey, consider joining in as a workshop TA! See FAQs below.  
+ 
+All the best,
+
+`r params$contact_person`, on behalf of Arcus Education and the CHOP R User Group Steering Committee
+
+**Intro to R Workshop TAs: Frequently Asked Questions**
+
+**Why might I want to be a workshop TA?**
+If you've had some beginner level exposure to R (such as attending an Intro to R workshop in the past) it can be hard to find ways to practice your new skills and consolidate your learning. Helping out with a workshop is a fantastic way to get exposure to the workshop content again, but with a new level of appreciation since you'll be thinking about things from a new perspective. 
+You also get increased visibility in the CHOPR community, which can launch new networking opportunities for you and possibly connect you to projects you wouldn't otherwise have found. If you've been mostly "lurking" in CHOPR so far, this is a great way to up your engagement. And TAing an Intro to R workshop is good experience to have --- put it on your resume, impress your manager! 
+Last but definitely not least, if you've found the CHOPR community useful so far in your R journey, helping at a workshop is a wonderful way to give back. Thank you for considering it.
+
+**What do workshop TAs do?**
+The primary role of TAs is to help with answering any questions they're able to that come up in the chat during the workshop. We'll also use breakout rooms at a couple points during the workshop, with one TA or instructor per room and 5-10 learners; these breakout sessions aren't for providing instruction (you're not expected to teach!), they're just time for introductions so learners can get to know each other a little, or small-group work sessions when everyone works on the same problem together. 
+
+**But I am still an R beginner myself. Surely, I don't know enough to TA, do I?**
+You do, I promise! TAs are not expected to be able to answer all the learner questions that come up --- if someone poses a question you don't know the answer to, just sit back and let someone else take a try. We have the workshop instructors and some other R experts on hand for tricky questions, so you're not alone. If it turns out you can't answer any questions through the whole workshop, that's still totally fine! We appreciate you being there. 
+We work hard to make this a community that's welcoming to beginners, and we find it's incredibly valuable to have workshop TAs that are just one step ahead of the learners themselves. You might find your limited R knowledge actually lets you connect with learners more effectively than the more experienced instructors can! Personal anecdotes about your own learning process as a beginner can be really helpful to folks just being exposed to R for the first time. 
+
+**What's the time commitment?**
+Ideally, we ask workshop TAs to be available for the duration of the workshop (9am-2pm) to try to answer questions that come up in the chat, but if you're only available for part of that time, still reach out! In addition to the workshop itself, we'll have one 30-min meeting with just the instructors and TAs a few days before the workshop to touch base. That's it!
+
+**Do you have advice for how to talk to my manager about getting the time to do this?**
+Depending on your normal work schedule, getting time to help with an all-day workshop can feel like a big ask. Every manager is different, but you may find it effective to frame your request in terms of how this experience will support your career and positional growth. Your engagement as an employee should be important to your supervisor, so hopefully they'll jump at the chance for you to have an enriching experience like this. And if nothing else, it's at least worth asking --- nothing ventured, nothing gained!
+
+**Okay, I might be interested. What are the next steps?**
+Woo-hoo! Send an email to me (`r params$contact_person` `r params$contact_email`) and I can answer any questions you have and, if you're ready, get you signed up to help. Thank you!
+ 
+*You're receiving this email because we think you're interested in R User Group meetings.  Want to stop receiving emails and invitations?  Let us know!  Was this forwarded to you by someone else and you'd like to receive these in the future? Sign up here:* https://redcap.chop.edu/surveys/?s=NPY49R9ARF.

--- a/workshop_communication/02_workshop_invite.rmd
+++ b/workshop_communication/02_workshop_invite.rmd
@@ -1,0 +1,59 @@
+---
+title: "Workshop Calendar Invite"
+output: html_document
+params:
+  workshop_date: "2022-02-17 09:00"
+  tech_check_date: "2022-02-16 13:00"
+  contact_person: "Rose Hartman"
+  contact_email: "hartmanr1@chop.edu"
+  signup_link: "https://redcap.link/feb2022_r_for_clinical_data"
+  pre_survey_link: "https://redcap.link/pre_r_for_clinical_data"
+  post_survey_link: "https://redcap.link/k1lyzn4e"
+  accounts_link: "www.example.com"
+  website_link: "https://arcus.github.io/intro-to-r-for-clinicians-chop/"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+library(lubridate)
+source("communication_functions.r")
+
+workshop_date <- ymd_hm(params$workshop_date, tz = "EST")
+tech_check_date <- ymd_hm(params$tech_check_date, tz = "EST")
+```
+*You are receiving this calendar invite because you are registered for the Intro to R for Clinical Data workshop on `r format(workshop_date, '%A, %B %d')`. If you believe this is in error or if you are unable to attend the workshop, please let us know as soon as possible so we can give your spot to someone else on the waiting list!*
+ 
+**Welcome to Intro to R for Clinical Data!**
+
+Hello, and thank you for enrolling in our workshop. Please hang on to this email! It has important info you will need on the day of the workshop. 
+ 
+Before the workshop: 
+
+-	Check out the [course website](`r params$website_link`) and complete the required pre-work. (Don’t worry, this won’t take much of your time!)
+
+-	Please take our [pre-course survey](`r params$pre_survey_link`) to allow us to better understand our users
+
+-	Optional: attend the pre-course technology check session on `r format(tech_check_date, '%A, %B %d')` `r print_time(tech_check_date, include_min=TRUE)` - `r print_time(tech_check_date + dminutes(30), include_min=TRUE)` (a separate invite will be sent for this session shortly)
+ 
+Day of the workshop: 
+
+- `r format(workshop_date, '%A, %B %d')` `r print_time(workshop_date)` - `r print_time(workshop_date + dhours(5))` with a 30-minute break for lunch
+
+- We will be using an RStudio server on the web. Click this link for your [username and password](`r params$accounts_link`).
+
+  *	Although the training environment is ephemeral and will not persist beyond the workshop session, please do not put any personal or sensitive information in your environment at any time
+  
+-	Zoom login info is at the bottom of this message
+
+-	Reminder: please have the latest versions of Google Chrome and Zoom downloaded and installed prior to the workshop.
+ 
+We look forward to seeing you! 
+ 
+Best,
+
+`r params$contact_person`, on behalf of Arcus Education and the CHOP R User Group
+
+**Zoom login information:** 
+
+

--- a/workshop_communication/03_tech_check_invite.Rmd
+++ b/workshop_communication/03_tech_check_invite.Rmd
@@ -1,0 +1,41 @@
+---
+title: "Tech Check Calendar Invite"
+output: html_document
+params:
+  workshop_date: "2022-02-17 09:00"
+  tech_check_date: "2022-02-16 13:00"
+  contact_person: "Rose Hartman"
+  contact_email: "hartmanr1@chop.edu"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+library(lubridate)
+source("communication_functions.r")
+
+workshop_date <- ymd_hm(params$workshop_date, tz = "EST")
+tech_check_date <- ymd_hm(params$tech_check_date, tz = "EST")
+```
+*You are receiving this calendar invite because you are registered for the Intro to R for Clinical Data workshop on `r format(workshop_date, '%A, %B %d')`. If you believe this is in error or if you are unable to attend the workshop, please let us know as soon as possible so we can give your spot to someone else on the waiting list!*
+
+Hello all,  
+ 
+Intro to R for Clinical Data is coming up soon, and we're looking forward to seeing you all there! You should have already received a calendar invite for the workshop itself, along with information about pre-work. If you haven't received the workshop information, please let us know!
+  
+ 
+On `r format(tech_check_date, '%A, %B %d')` `r print_time(tech_check_date, include_min=TRUE)`-`r print_time(tech_check_date + dminutes(30), include_min=TRUE)`, we will be holding a brief technology check-in to make sure that everyone is able to log into Zoom, the RStudio training environment, etc. 
+ 
+Though this event is optional, please plan to attend for at least a few minutes if possible. This will allow us to hit the ground running on `r format(workshop_date, '%a %m/%d')`. 
+ 
+The information to join the Zoom meeting is at the bottom of this email. 
+ 
+Please reach out with any questions you might have! 
+ 
+All the best, 
+
+`r params$contact_person`, on behalf of Arcus Education and the CHOP R User Group 
+
+**Zoom login information:** 
+
+

--- a/workshop_communication/04_post_workshop.Rmd
+++ b/workshop_communication/04_post_workshop.Rmd
@@ -1,0 +1,74 @@
+---
+title: "Post Workshop Email"
+output: html_document
+params:
+  contact_person: "Rose Hartman"
+  contact_email: "hartmanr1@chop.edu"
+  post_survey_link: "https://redcap.link/k1lyzn4e"
+  website_link: "https://arcus.github.io/intro-to-r-for-clinicians-chop/"
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+Hi all, 
+ 
+Thank you so much for attending our Intro to R for Clinical Data course yesterday!
+ 
+I know we threw a lot of information and resources at you, so here's a recap. 
+ 
+**Stay involved with us:**
+
+-	Please take our brief [post-course survey](`r params$post_survey_link`) to help us improve for future learners. We read these responses carefully and really do use the feedback to shape future offerings, so please take a moment to fill it out if you have anything to share with us about what went well or what we could do better. Thank you!
+-	[Join the CHOP R User Group](https://redcap.chop.edu/surveys/?s=NPY49R9ARF) if you haven't already – you'll be added to our mailing list for future events, plus receive an invite to our slack (which is a great place to ask coding questions as you continue along your journey to learning R). 
+-	Come to [R office hours](https://bit.ly/chopROfficeHours) to get help with your R code 
+ 
+**Workshop-specific materials:**
+
+-	[Course website](`r params$website_link`)
+- You can download all of the workshop materials from our GitHub repo: our [slides](https://github.com/arcus/intro-to-r-for-clinicians-chop/tree/master/slides), the hands-on [exercises](https://github.com/arcus/intro-to-r-for-clinicians-chop/tree/master/exercises) we did during the workshop, and corresponding [solutions](https://github.com/arcus/intro-to-r-for-clinicians-chop/tree/master/solutions). If you have any trouble access them, let us know!
+-	We recorded the workshop and will be posting it soon. Stay tuned!
+
+**Resources and suggestions for more learning:**
+
+-	[R for Data Science](https://r4ds.had.co.nz/) is an incredible (FREE!) online text that is perhaps the most popular intro to data science with R out there. Our course was designed so that you can easily pick up this book and continue learning. (en español: https://es.r4ds.hadley.nz/) 
+    *	There's a great [unofficial solutions guide](https://jrnold.github.io/r4ds-exercise-solutions/index.html) so you can check your work as you go
+    *	Also, our very own Meredith Lee has been working on a lovely companion series of brief articles to go along with the book, currently covering chapters 1-7. Find [Chapter 1 here](https://education.arcus.chop.edu/r-4-beginners-chapter-1/). If you start working through the book and find you'd like to contribute an article like this to our website, let us know! These guides are meant to be "for beginners, by beginners", so don't feel like you need to be an expert to contribute.
+- Check out this article for additional context on ["messy" and "tidy" data](https://education.arcus.chop.edu/tidyverse/)
+- Check out this article for more on [file paths](https://education.arcus.chop.edu/file-paths), a common stumbling block when trying to import data into R
+- For more on options for code chunks in R-Markdown documents, see this [RStudio tutorial](https://rmarkdown.rstudio.com/lesson-3.html) (we talked about message=FALSE and  echo=FALSE during the workshop)
+- For more on using languages other than R in your R-Markdown documents, see the section on [language engines in the R Markdown book](https://bookdown.org/yihui/rmarkdown/language-engines.html). Python, Julia, SQL, SAS, and STATA are all options!
+- For more on using colors in ggplot, check out the R Graph Gallery. There is a nice little interactive widget that shows options in real time with code of how to change colors: https://www.r-graph-gallery.com/ggplot2-color.html
+-	[RStudio Primers](https://rstudio.cloud/learn/primers) (online self-paced tutorials)
+-	[Cheatsheets](https://www.rstudio.com/resources/cheatsheets/)
+    *	We talked in particular about the [import](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-import.pdf), [visualization](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-visualization.pdf), and [transformation](https://raw.githubusercontent.com/rstudio/cheatsheets/main/data-transformation.pdf) cheatsheets
+    * Note that you can also access cheatsheets directly in RStudio from the Help menu at the top (scroll down to "Cheatsheets" and then select the cheatsheet you wish to view)
+  
+**Opportunities to practice R:**
+
+- Check out [Tidy Tuesday](https://www.tidytuesday.com/), a weekly data visualization challenge. It's great practice to try doing the challenges yourself, and you can also learn a lot from looking at the code other people come up with. 
+- We're in the process of converting the slides from this workshop into R-Markdown files, and we'd love your help! If you're interested to learn about how you can make slide decks in R-Markdown and you like the idea of reviewing the workshop content at the same time, get in touch (`r params$contact_email`). There's no minimum time commitment --- if you just have a few minutes and you want to try it out, that's perfectly fine! 
+ 
+**Packages brought up in chat:**
+
+-	Package for reading SAS, SPSS, and STATA files: https://haven.tidyverse.org/
+- For instructions and examples on how to get data from redcap into R, see the following articles:
+  * https://education.arcus.chop.edu/redcap-r-windows/
+  * https://education.arcus.chop.edu/redcap-api/
+  * Not sure what the heck an API is? Start with [this article](https://education.arcus.chop.edu/what-is-an-api/)
+-	Package for dealing with date-time data: https://lubridate.tidyverse.org/
+- For more ways to select columns (other than just by spelling out their names, as we did in the workshop), learn about using [tidy select functions from the dplyr package](https://dplyr.tidyverse.org/reference/dplyr_tidy_select.html)
+ 
+**Keyboard shortcuts:**
+
+-	Insert %>% (pipe operator) Ctrl + Shift + M (Windows) or Command + Shift + M (Mac)
+-	Insert <- (assignment operator) Alt + - (Windows) or Option + - (Mac
+-	Insert code chunk (in .rmd files) Ctrl + Alt + I (Windows) or Command + Option + I (Mac)
+- Here is [a complete list of the keyboard shortcuts in RStudio](https://support.rstudio.com/hc/en-us/articles/200711853-Keyboard-Shortcuts-in-the-RStudio-IDE); you can also access this list directly in RStudio from the Help menu at the top (scroll down to "Keyboard Shortcuts Help")
+ 
+Please feel free to reach out with any questions. We look forward to seeing you again in future offerings! 
+ 
+All the best,
+
+`r params$contact_person`, On behalf of Arcus Education and the CHOP R User Group

--- a/workshop_communication/README.md
+++ b/workshop_communication/README.md
@@ -1,0 +1,52 @@
+## Using the rmd files for workshop communication
+
+This folder contains rmd files that are [parameterized reports](https://bookdown.org/yihui/rmarkdown/parameterized-reports.html). That means you can change the parameters at the top and then knit to have the report update with the new information. Parameters include the following:
+
+- contact person (generally the team member sending all these emails)
+- contact email (their email)
+- workshop date, including start time (duration assumed to be 5h)
+- tech check date, including start time (duration assumed to be 30m)
+- link to signup
+- link to pre course survey
+- link to post course survey
+- link to course website
+- link to server accounts for use during workshop
+
+To generate the text for emails for a new workshop, you should be able to update just the parameters and knit, then copy-paste the resulting html into your email and send. 
+
+**Note:** The text of the post-workshop email will change depending on the conversation that arises during the workshop. Update it as needed based on the chat record from zoom.
+
+There is an R file of functions that get used in the rmd reports (communication_functions.r). 
+
+## Additional tasks
+
+### Check signups and move folks from wait list
+
+After the initial workshop invite goes out, you'll need to keep checking the signup form daily for new people and add them to the invites for the workshop and tech check. If there's a wait list, then as people email to drop their registration, contact people from the wait list to offer them the spot. 
+
+### Recruit TAs
+
+Keep an eye on registrations to see if you recognize folks who have already taken the workshop in the past. If so, reach out to them and ask if they'd like to try TAing instead (see FAQs for workshop TAs in 01_announcement). Also post in the R User Group slack, and contact the Data Ambassadors. 
+
+### Zoom info
+
+In addition, you'll need to set up zoom rooms for the tech check and workshop, and then copy-paste that zoom login information into the calendar invites for each (02_workshop_invite and 03_tech_check_invite, respectively).
+
+### Save chat record during meeting
+
+Before the zoom call for the workshop ends, save the chat record. You'll need this to update the post-workshop email. 
+
+### Attendance record
+
+After the workshop, get a list of attendees who actually showed up:
+
+* Log In to zoom
+* Click My account in top right
+* On lefthand side bar,  under admin, open Account Management dropdown
+* Then, reports. 
+* In reports, go to Active hosts. 
+* Set date range meeting occurred in. 
+* Participants column (may need to scroll over to see) -> click on the link! 
+* Export as .csv
+
+You can use this list to update attendance in redcap with attended vs cancelled vs no showed. 

--- a/workshop_communication/communication_functions.r
+++ b/workshop_communication/communication_functions.r
@@ -1,0 +1,21 @@
+
+print_time <- function(datetime, include_min = FALSE){
+  stopifnot(require(lubridate))
+  
+  if(include_min){
+    if(am(datetime)){
+      time <- paste0(format(datetime, '%I:%M'), "am")
+    } else {
+      time <- paste0(format(datetime, '%I:%M'), "pm")
+    }
+  } else {
+    if(am(datetime)){
+      time <- paste0(hour(datetime), "am")
+    } else {
+      time <- paste0(hour(datetime)-12, "pm")
+    }
+  }
+  # remove initial zero, if there
+  time <- gsub(x = time, pattern ="^0", replacement = "")
+  return(time)
+}


### PR DESCRIPTION
I converted the word docs we had been using to keep drafts and versions of workshop emails to .rmd parameterized reports. I also added a README explaining how to use the reports and what communication tasks have to get done when. 